### PR TITLE
refactor(Blox.CommentController): use assoc to delete comment

### DIFF
--- a/web/controllers/comment_controller.ex
+++ b/web/controllers/comment_controller.ex
@@ -26,12 +26,7 @@ defmodule Blox.CommentController do
 
   def delete(conn, %{"id" => id}) do
     post = conn.assigns[:post]
-
-    comment = Comment
-    |> where([c], c.id == ^id)
-    |> where([c], c.post_id == ^post.id)
-    |> Blox.Repo.one!
-
+    comment = post |> Ecto.Model.assoc(:comments) |> Blox.Repo.get(id)
     Blox.Repo.delete!(comment)
 
     redirect conn, to: post_path(conn, :show, post)


### PR DESCRIPTION
When deleting the comment, the explicit query has been replaced by one
generated using `Ecto.Model.assoc/2`

> http://hexdocs.pm/ecto/0.12.0/Ecto.Model.html#assoc/2
